### PR TITLE
Use official Homebrew Cask tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ Unzip, drag the app to Applications, and then run it.
 If you wish to install the application from Homebrew:
 
 ```
-$ brew tap dteoh/devdocs
-$ brew cask install devdocs-macos
+$ brew cask install dteoh-devdocs
 ```
 
 The application will live at `/Applications/DevDocs.app`.


### PR DESCRIPTION
DevDocs has been added to Homebrew Cask: https://github.com/Homebrew/homebrew-cask/pull/86103
This PR updates readme to use official tap :tada: