### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Unzip, drag the app to Applications, and then run it.
 If you wish to install the application from Homebrew:
 
 ```
-$ brew cask install dteoh-devdocs
+$ brew install --cask dteoh-devdocs
 ```
 
 The application will live at `/Applications/DevDocs.app`.
@@ -76,9 +76,9 @@ The application had a tap maintained by the project. To migrate to the default
 tap:
 
 ```
-$ brew cask uninstall devdocs-macos
+$ brew uninstall --cask devdocs-macos
 $ brew untap dteoh/devdocs
-$ brew cask install dteoh-devdocs
+$ brew install --cask dteoh-devdocs
 ```
 
 ### Compatibility


### PR DESCRIPTION
Fixed cask commands (Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead)